### PR TITLE
Target wayfarer added

### DIFF
--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -36,7 +36,7 @@ install:
         #!/bin/bash
 
         cd /opt/targets/wayfarer
-        deploy.sh
+        ./deploy.sh
       mode: 0744
 
   - name: Setup hosts file entries (ticket app wtf)

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -84,7 +84,6 @@ remove:
         - /etc/nginx/conf.d/wayfarer-ticket-app.conf
         - /etc/nginx/conf.d/wayfarer-ticket-api.conf
         - /opt/targets/wayfarer/.env
-
   - lineinfile:
       dest: /etc/hosts
       line: '127.0.0.9   wayfarer.wtf'
@@ -97,27 +96,25 @@ remove:
       dest: /etc/hosts
       line: '127.0.0.9   api.wayfarer.test'
       state: absent
-
   - service:
       name: nginx
       state: restarted
   - command:
       cmd: systemctl daemon-reload
 
-  start:
-    - command:
-        pwd: /opt/targets/wayfarer
-        cmd: bash deploy.sh
+start:
+  - command:
+      pwd: /opt/targets/wayfarer
+      cmd: bash deploy.sh
 
-  stop:
-    - command:
-        cmd: docker stack rm wayfarer
+stop:
+  - command:
+      cmd: docker stack rm wayfarer
 
-  status:
-    running:
-      started:
-        docker: wayfarer-db 
-
+status:
+  running:
+    started:
+      docker: wayfarer-db 
   installed:
     exists:
       path: /opt/targets/wayfarer

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -29,6 +29,16 @@ install:
         USE_TLS=FALSE
       mode: 0744
 
+  - name: Script to start Wayfarer
+    copy:
+      dest: /usr/local/bin/start_wayfarer.sh
+      content: |
+        #!/bin/bash
+
+        cd /opt/targets/wayfarer
+        deploy.sh
+      mode: 0744
+
   - name: Setup hosts file entries (ticket app wtf)
     lineinfile:
       dest: /etc/hosts
@@ -104,8 +114,7 @@ remove:
 
 start:
   - command:
-      pwd: /opt/targets/wayfarer
-      cmd: /opt/targets/wayfarer/deploy.sh
+      cmd: /usr/local/bin/start_wayfarer.sh
 
 stop:
   - command:

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -116,13 +116,13 @@ install:
 
 remove:
   - service:
-      name: wtf-musashi
+      name: wtf-wayfarer
       state: stopped
   - rm:
       path:
         - /opt/targets/wayfarer
-        - /usr/local/bin/start_musashi.sh
-        - /etc/systemd/system/wtf-musashi.service
+        - /usr/local/bin/start_wayfarer.sh
+        - /etc/systemd/system/wtf-wayfarer.service
         - /etc/nginx/conf.d/wayfarer-ticket-app.conf
         - /etc/nginx/conf.d/wayfarer-ticket-api.conf
         - /opt/targets/wayfarer/.env

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -41,6 +41,7 @@ install:
         cd /opt/targets/wayfarer
         ./deploy.sh
       mode: 0744
+      force: true
 
   - name: Setup hosts file entries (ticket app wtf)
     lineinfile:

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -105,7 +105,7 @@ remove:
 start:
   - command:
       pwd: /opt/targets/wayfarer
-      cmd: bash deploy.sh
+      cmd: /opt/targets/wayfarer/deploy.sh
 
 stop:
   - command:

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -51,9 +51,9 @@ install:
         [Service]
         Type=oneshot
         RemainAfterExit=yes
+        User=samurai
         ExecStart=/usr/local/bin/start_wayfarer.sh
-        ExecStop=/usr/local/bin/stop_wayfarer.sh
-
+   
         [Install]
         WantedBy=multi-user.target
       mode: 0744

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -31,6 +31,7 @@ install:
         API_CORS_POLICY=^https?\:\/\/wayfarer\.
         USE_TLS=FALSE
       mode: 0744
+      force: true
 
   - name: Script to start Wayfarer
     copy:
@@ -41,7 +42,6 @@ install:
         cd /opt/targets/wayfarer
         ./deploy.sh
       mode: 0744
-      force: true
 
   - name: Setup hosts file entries (ticket app wtf)
     lineinfile:

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -1,0 +1,165 @@
+---
+
+name: wayfarer
+category: targets
+description: A modern react/express app for app security labs.
+href: http://wayfarer.test
+
+install:
+  - name: Get the latest release of wayfarer
+    git:
+      repo: https://github.com/SamuraiWTF/wayfarer.git
+      dest: /opt/targets/wayfarer
+
+  - name: Build the docker images
+    command: 
+      cwd: /opt/targets/wayfarer
+      cmd: ./build.sh
+
+  - name: Initialize Docker Swarm
+    command:
+      cmd: docker swarm init --advertise-addr eth0
+
+  - name: Script to start Wayfarer
+    copy:
+      dest: /usr/local/bin/start_wayfarer.sh
+      content: |
+        #!/bin/bash
+
+        cd /opt/targets/wayfarer
+        ./deploy.sh
+      mode: 0744
+
+  - name: Script to stop Wayfarer
+    copy:
+      dest: /usr/local/bin/stop_wayfarer.sh
+      content: |
+        #!/bin/bash
+
+        docker stack rm wayfarer
+      mode: 0744
+
+  - name: Create service descriptor for wtf-wayfarer.service
+    copy:
+      dest: /etc/systemd/system/wtf-wayfarer.service
+      content: |
+        [Unit]
+        Description=Wayfarer Target service
+        Requires=docker.service
+        After=docker.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/local/bin/start_wayfarer.sh
+        ExecStop=/usr/local/bin/stop_wayfarer.sh
+
+        [Install]
+        WantedBy=multi-user.target
+      mode: 0744
+
+  - name: Generate wayfarer .env file
+    copy:
+      dest: /opt/targets/wayfarer/.env
+      content: |
+        CORS_API_PORT=3020
+        CORS_API_HOST=api.cors.dem
+        USE_TLS=FALSE
+      mode: 0744
+
+  - name: Setup hosts file entries (ticket app wtf)
+    lineinfile:
+      dest: /etc/hosts
+      line: '127.0.0.9   wayfarer.wtf'
+
+  - name: Setup hosts file entries (ticket app test)
+    lineinfile:
+      dest: /etc/hosts
+      line: '127.0.0.9   wayfarer.test'
+
+  - name: Setup nginx reverse-proxy config for app
+    copy:
+      dest: /etc/nginx/conf.d/wayfarer-ticket-app.conf
+      content: |
+        server {
+          listen 80;
+          server_name wayfarer.wtf wayfarer.test;
+          location / {
+            proxy_pass http://localhost:7000;
+          }
+        }
+      mode: 0644
+
+  - name: Setup hosts file entries for api (test)
+    lineinfile:
+      dest: /etc/hosts
+      line: '127.0.0.9   api.wayfarer.test'
+
+  - name: Setup nginx reverse-proxy config for ticket API
+    copy:
+      dest: /etc/nginx/conf.d/wayfarer-ticket-api.conf
+      content: |
+        server {
+          listen 80;
+          server_name api.wayfarer.test;
+          location / {
+            proxy_pass http://localhost:7001;
+          }
+        }
+      mode: 0644
+
+  - service:
+      name: nginx
+      state: restarted
+  - command:
+      cmd: systemctl daemon-reload
+
+remove:
+  - service:
+      name: wtf-musashi
+      state: stopped
+  - rm:
+      path:
+        - /opt/targets/wayfarer
+        - /usr/local/bin/start_musashi.sh
+        - /etc/systemd/system/wtf-musashi.service
+        - /etc/nginx/conf.d/wayfarer-ticket-app.conf
+        - /etc/nginx/conf.d/wayfarer-ticket-api.conf
+        - /opt/targets/wayfarer/.env
+
+  - lineinfile:
+      dest: /etc/hosts
+      line: '127.0.0.9   wayfarer.wtf'
+      state: absent
+  - lineinfile:
+      dest: /etc/hosts
+      line: '127.0.0.9   wayfarer.test'
+      state: absent
+  - lineinfile:
+      dest: /etc/hosts
+      line: '127.0.0.9   api.wayfarer.test'
+      state: absent
+
+  - service:
+      name: nginx
+      state: restarted
+  - command:
+      cmd: systemctl daemon-reload
+
+
+start:
+  - service:
+      name: wtf-wayfarer
+      state: running
+
+stop:
+  - service:
+      name: wtf-wayfarer
+      state: stopped
+
+status:
+  running:
+    started:
+      service: wtf-wayfarer
+  installed:
+    exists:
+      path: /opt/targets/wayfarer

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -104,20 +104,20 @@ remove:
   - command:
       cmd: systemctl daemon-reload
 
+  start:
+    - command:
+        pwd: /opt/targets/wayfarer
+        cmd: bash deploy.sh
 
-start:
-  - command:
-      pwd: /opt/targets/wayfarer
-      cmd: bash deploy.sh
-
-stop:
-  - command:
-      cmd: docker stack rm wayfarer
+  stop:
+    - command:
+        cmd: docker stack rm wayfarer
 
   status:
     running:
       started:
         docker: wayfarer-db 
+
   installed:
     exists:
       path: /opt/targets/wayfarer

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -20,44 +20,6 @@ install:
     command:
       cmd: docker swarm init --advertise-addr eth0
 
-  - name: Script to start Wayfarer
-    copy:
-      dest: /usr/local/bin/start_wayfarer.sh
-      content: |
-        #!/bin/bash
-
-        cd /opt/targets/wayfarer
-        ./deploy.sh
-      mode: 0744
-
-  - name: Script to stop Wayfarer
-    copy:
-      dest: /usr/local/bin/stop_wayfarer.sh
-      content: |
-        #!/bin/bash
-
-        docker stack rm wayfarer
-      mode: 0744
-
-  - name: Create service descriptor for wtf-wayfarer.service
-    copy:
-      dest: /etc/systemd/system/wtf-wayfarer.service
-      content: |
-        [Unit]
-        Description=Wayfarer Target service
-        Requires=docker.service
-        After=docker.service
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        User=samurai
-        ExecStart=/usr/local/bin/start_wayfarer.sh
-   
-        [Install]
-        WantedBy=multi-user.target
-      mode: 0744
-
   - name: Generate wayfarer .env file
     copy:
       dest: /opt/targets/wayfarer/.env
@@ -115,14 +77,10 @@ install:
       cmd: systemctl daemon-reload
 
 remove:
-  - service:
-      name: wtf-wayfarer
-      state: stopped
   - rm:
       path:
         - /opt/targets/wayfarer
         - /usr/local/bin/start_wayfarer.sh
-        - /etc/systemd/system/wtf-wayfarer.service
         - /etc/nginx/conf.d/wayfarer-ticket-app.conf
         - /etc/nginx/conf.d/wayfarer-ticket-api.conf
         - /opt/targets/wayfarer/.env
@@ -148,19 +106,18 @@ remove:
 
 
 start:
-  - service:
-      name: wtf-wayfarer
-      state: running
+  - command:
+      pwd: /opt/targets/wayfarer
+      cmd: bash deploy.sh
 
 stop:
-  - service:
-      name: wtf-wayfarer
-      state: stopped
+  - command:
+      cmd: docker stack rm wayfarer
 
-status:
-  running:
-    started:
-      service: wtf-wayfarer
+  status:
+    running:
+      started:
+        docker: wayfarer-db 
   installed:
     exists:
       path: /opt/targets/wayfarer

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -50,6 +50,7 @@ install:
 
         [Service]
         Type=oneshot
+        RemainAfterExit=yes
         ExecStart=/usr/local/bin/start_wayfarer.sh
         ExecStop=/usr/local/bin/stop_wayfarer.sh
 

--- a/modules/targets/wayfarer.yml
+++ b/modules/targets/wayfarer.yml
@@ -24,8 +24,11 @@ install:
     copy:
       dest: /opt/targets/wayfarer/.env
       content: |
-        CORS_API_PORT=3020
-        CORS_API_HOST=api.cors.dem
+        REACT_APP_API_ORIGIN=http://api.wayfarer.test
+        API_PUBLIC_PORT=7001
+        APP_PORT=7000
+        API_CORS_TYPE=regex
+        API_CORS_POLICY=^https?\:\/\/wayfarer\.
         USE_TLS=FALSE
       mode: 0744
 


### PR DESCRIPTION
Install, start, and stop commands are working. Creates the `.env` file to make the parameters appropriate for Samurai.
Status currently misreports as stopped, looks like that's a gap in the Docker plugin. Will fix later.