### PR TITLE
Add SSL to Juice-Shop (first target proof-of-concept)

### DIFF
--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -46,19 +46,23 @@ install:
       dest: /etc/hosts
       line: '127.0.0.1   juice-shop.test'
 
-  - name: Install mkcert root ca
-    command:
-      cmd: mkcert -install
+  - name: Create SSL setup script
+    copy:
+      dest: /tmp/setup_juiceshop_ssl.ssh
+      content: |
+      #!/bin/bash
+      export CAROOT=/opt/samurai/mkcert
+      mkcert -install
+      cd /etc/nginx/certs
+      mkcert juice-shop.wtf juice-shop.test
 
-  - name: Create nginx certs directory
+  - name: Execute SSL setup
     command:
-      cwd: /etc/nginx
-      cmd: mkdir certs
+      cmd: bash /tmp/setup_juiceshop_ssl.sh
 
-  - name: Generate SSL certs with mkcert
+  - name: Cleanup SSL script
     command:
-      cwd: /etc/nginx/certs
-      cmd: mkcert juice-shop.wtf juice-shop.test
+      cmd: rm /tmp/setup_juiceshop_ssl.sh
 
   - name: Setup nginx reverse-proxy config
     copy:
@@ -77,7 +81,7 @@ install:
           location / {
             proxy_pass http://localhost:3000;
           }
-          ssl_certficate certs/juice-shop.wtf+1.pem;
+          ssl_certificate certs/juice-shop.wtf+1.pem;
           ssl_certificate_key certs/juice-shop.wtf+1-key.pem;
         }
       mode: 0644
@@ -100,6 +104,10 @@ remove:
       path: /etc/systemd/system/wtf-juice-shop.service
   - rm:
       path: /etc/nginx/conf.d/juice-shop.conf
+  - rm:
+      path: /etc/nginx/certs/juice-shop.wtf+1.pem
+  - rm:
+      path: /etc/nginx/certs/juice-shop.wtf+1-key.pem
   - name: Remove hosts file entries (wtf)
     lineinfile:
       dest: /etc/hosts

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -77,8 +77,8 @@ install:
           location / {
             proxy_pass http://localhost:3000;
           }
-          ssl_certficate certs/juice-shop.wtf+1.pem
-          ssl_certificate_key certs/juice-shop.wtf+1-key.pem
+          ssl_certficate certs/juice-shop.wtf+1.pem;
+          ssl_certificate_key certs/juice-shop.wtf+1-key.pem;
         }
       mode: 0644
 

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -51,6 +51,7 @@ install:
       cmd: mkcert -install
 
   - name: Create nginx certs directory
+    command:
       cwd: /etc/nginx
       cmd: mkdir certs
 

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -52,7 +52,8 @@ install:
 
   - name: Generate SSL certs with mkcert
     command:
-      cmd: cd /etc/nginx/conf.d && mkcert juice-shop.wtf juice-shop.test
+      cwd: /etc/nginx/conf.d
+      cmd: mkcert juice-shop.wtf juice-shop.test
 
   - name: Setup nginx reverse-proxy config
     copy:

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -48,7 +48,7 @@ install:
 
   - name: Create SSL setup script
     copy:
-      dest: /tmp/setup_juiceshop_ssl.ssh
+      dest: /tmp/setup_juiceshop_ssl.sh
       content: |
         #!/bin/bash
         export CAROOT=/opt/samurai/mkcert

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -46,6 +46,14 @@ install:
       dest: /etc/hosts
       line: '127.0.0.1   juice-shop.test'
 
+  - name: Install mkcert root ca
+    command:
+      cmd: mkcert -install
+
+  - name: Generate SSL certs with mkcert
+    command:
+      cmd: cd /etc/nginx/conf.d && mkcert juice-shop.wtf juice-shop.test
+
   - name: Setup nginx reverse-proxy config
     copy:
       dest: /etc/nginx/conf.d/juice-shop.conf

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -50,9 +50,13 @@ install:
     command:
       cmd: mkcert -install
 
+  - name: Create nginx certs directory
+      cwd: /etc/nginx
+      cmd: mkdir certs
+
   - name: Generate SSL certs with mkcert
     command:
-      cwd: /etc/nginx/conf.d
+      cwd: /etc/nginx/certs
       cmd: mkcert juice-shop.wtf juice-shop.test
 
   - name: Setup nginx reverse-proxy config
@@ -65,6 +69,15 @@ install:
           location / {
             proxy_pass http://localhost:3000;
           }
+        }
+        server {
+          listen 443 ssl;
+          server_name juice-shop.wtf juice-shop.test;
+          location / {
+            proxy_pass http://localhost:3000;
+          }
+          ssl_certficate certs/juice-shop.wtf+1.pem
+          ssl_certificate_key certs/juice-shop.wtf+1-key.pem
         }
       mode: 0644
 

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -50,11 +50,11 @@ install:
     copy:
       dest: /tmp/setup_juiceshop_ssl.ssh
       content: |
-      #!/bin/bash
-      export CAROOT=/opt/samurai/mkcert
-      mkcert -install
-      cd /etc/nginx/certs
-      mkcert juice-shop.wtf juice-shop.test
+        #!/bin/bash
+        export CAROOT=/opt/samurai/mkcert
+        mkcert -install
+        cd /etc/nginx/certs
+        mkcert juice-shop.wtf juice-shop.test
 
   - name: Execute SSL setup
     command:


### PR DESCRIPTION
 - _IMPORTANT NOTE:_ This is a **breaking change** with Samurai compatibility. It requires Samurai to be setup with `mkcert`, which have in an open PR - https://github.com/SamuraiWTF/samuraiwtf/pull/158
 - Added 443 to Juice-Shop's nginx config
 - Added automatic generation of juice-shop certs with `mkcert`
 - Note that the browsers' cert trust can't be automatically set with mkcert until after they're first run. After they're run, `mkcert -install` run as the primary user will fix the trust, but the browser will need to be restarted.