### PR TITLE
change url to new repo

### DIFF
--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -8,7 +8,7 @@ href: http://juice-shop.test
 install:
   - name: Get the latest release page of Juice Shop
     get_url:
-      url: https://github.com/bkimminich/juice-shop/releases/latest
+      url: https://github.com/juice-shop/juice-shop/releases/latest
       dest: /opt/targets/juice-shop
       link_pattern: \/bkimminich\/juice-shop\/releases\/download\/.*_node12_linux_x64.tgz
 

--- a/modules/targets/juice-shop.yml
+++ b/modules/targets/juice-shop.yml
@@ -10,7 +10,7 @@ install:
     get_url:
       url: https://github.com/juice-shop/juice-shop/releases/latest
       dest: /opt/targets/juice-shop
-      link_pattern: \/bkimminich\/juice-shop\/releases\/download\/.*_node12_linux_x64.tgz
+      link_pattern: \/juice-shop\/juice-shop\/releases\/download\/.*_node12_linux_x64.tgz
 
   - name: Script to start juice shop
     copy:


### PR DESCRIPTION
This points the manifest to the new JuiceShop repo, as it was moved recently.