### PR TITLE
Fixed error when installing tools (like sqlmap or wordlists) via web

### DIFF
--- a/katanacore.py
+++ b/katanacore.py
@@ -73,11 +73,11 @@ def _run_function(module_name, function_name, step=False):
         raise katanaerrors.NotImplemented(function_name, type(provisioner).__name__)
 
 
-def install_module(name, step):
+def install_module(name, step=False):
     _run_function(name, "install", step)
 
 
-def remove_module(name, step):
+def remove_module(name, step=False):
     _run_function(name, "remove", step)
 
 


### PR DESCRIPTION
Error message:

```
Mar  8 14:36:35 SamuraiWTF python3[684]: Exception in thread Thread-21:
Mar  8 14:36:35 SamuraiWTF python3[684]: Traceback (most recent call last):
Mar  8 14:36:35 SamuraiWTF python3[684]:   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
Mar  8 14:36:35 SamuraiWTF python3[684]:     self.run()
Mar  8 14:36:35 SamuraiWTF python3[684]:   File "/usr/lib/python3.8/threading.py", line 870, in run
Mar  8 14:36:35 SamuraiWTF python3[684]:     self._target(*self._args, **self._kwargs)
Mar  8 14:36:35 SamuraiWTF python3[684]: TypeError: install_module() missing 1 required positional argument: 'step'
Mar  8 14:36:35 SamuraiWTF python3[684]: checking status for {'installed': {'exists': {'path': '/opt/samurai/wordlists'}}}
Mar  8 14:36:35 SamuraiWTF python3[684]: doing installed check...
Mar  8 14:36:35 SamuraiWTF python3[684]: Check pair: {'path': '/opt/samurai/wordlists'}
Mar  8 14:36:35 SamuraiWTF python3[684]: found check 'path' with value '/opt/samurai/wordlists'.
Mar  8 14:36:35 SamuraiWTF python3[684]: check plugin: <plugins.Exists.Exists object at 0x7f377472d9a0>
Mar  8 14:36:35 SamuraiWTF python3[684]: 127.0.0.1 - - [08/Mar/2023:14:36:35] "GET /status/wordlists HTTP/1.0" 200 82 "https://katana.test:8443/" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64
```