### PR TITLE
Fix release workflow to trigger on published release event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Replace `push: tags: 'v*'` trigger with `release: types: [published]`
- Binaries are now only built and attached to a release when explicitly published via the GitHub UI
- Prevents accidental binary builds from stray tag pushes or draft releases

## Test plan

- [ ] Publish a new release in GitHub UI and verify the workflow runs and attaches the `katana-linux-x64` binary
- [ ] Verify that pushing a tag alone does NOT trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)