### PR TITLE
Add ARM64 Linux release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@ jobs:
           ./katana-linux-x64 --version
           ./katana-linux-x64 --help
 
+      - name: Verify release artifacts
+        run: |
+          ls -lh katana-linux-*
+          file katana-linux-x64
+          file katana-linux-arm64
+
       - name: Extract version from tag
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,13 @@ jobs:
       - name: Build UI
         run: bun run src/ui/build.ts
 
-      - name: Build binary for Linux
+      - name: Build Linux binaries
         run: |
           bun build src/cli.ts --compile --target=bun-linux-x64 --outfile katana-linux-x64
-          chmod +x katana-linux-x64
+          bun build src/cli.ts --compile --target=bun-linux-arm64 --outfile katana-linux-arm64
+          chmod +x katana-linux-x64 katana-linux-arm64
 
-      - name: Test binary
+      - name: Test x64 binary
         run: |
           ./katana-linux-x64 --version
           ./katana-linux-x64 --help
@@ -63,6 +64,7 @@ jobs:
           body_path: release_notes.md
           files: |
             katana-linux-x64
+            katana-linux-arm64
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Summary

Adds a Linux ARM64 Katana release artifact alongside the existing x64 binary.

This enables Katana to run natively inside ARM64 Linux environments, including SamuraiWTF virtual machines running on Apple Silicon.

## Changes

* Builds `katana-linux-arm64` using Bun
* Verifies both Linux release artifacts and their architectures
* Publishes both `katana-linux-x64` and `katana-linux-arm64` with GitHub releases

## Testing

Tested using:

* Apple Silicon Mac
* VMware Fusion
* Ubuntu 22 ARM64 SamuraiWTF VM

Validation performed:

* Successfully compiled `katana-linux-arm64`
* Confirmed the output is an ARM aarch64 Linux executable
* Installed the binary inside the SamuraiWTF ARM64 VM
* Verified `katana --version` returns `2.0.0`
* Verified `katana --help` and the available CLI commands load successfully

The existing x64 build and release behavior remains unchanged.
