### PR TITLE
Add ARM64 release for Linux and Apple Silicon hosts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@ jobs:
           ./katana-linux-x64 --version
           ./katana-linux-x64 --help
 
+      - name: Verify release artifacts
+        run: |
+          ls -lh katana-linux-*
+          file katana-linux-x64
+          file katana-linux-arm64
+
       - name: Extract version from tag
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,13 @@ jobs:
       - name: Build UI
         run: bun run src/ui/build.ts
 
-      - name: Build binary for Linux
+      - name: Build Linux binaries
         run: |
           bun build src/cli.ts --compile --target=bun-linux-x64 --outfile katana-linux-x64
-          chmod +x katana-linux-x64
+          bun build src/cli.ts --compile --target=bun-linux-arm64 --outfile katana-linux-arm64
+          chmod +x katana-linux-x64 katana-linux-arm64
 
-      - name: Test binary
+      - name: Test x64 binary
         run: |
           ./katana-linux-x64 --version
           ./katana-linux-x64 --help
@@ -63,6 +64,7 @@ jobs:
           body_path: release_notes.md
           files: |
             katana-linux-x64
+            katana-linux-arm64
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Summary

Add ARM64 support to Katana's Linux releases, allowing Katana to run natively on ARM64 systems.

## Motivation

SamuraiWTF now supports ARM64 environments. Publishing ARM64 Linux releases allows users running SamuraiWTF on Apple Silicon Macs (M1, M2, M3, and M4) to use Katana natively inside their Linux virtual machines instead of relying on x86 emulation or building Katana from source.

## Changes

- Add ARM64 support to the Linux release process.
- Verify both x64 and ARM64 Linux releases are generated successfully.

## Testing

- Verified both x64 and ARM64 Linux releases are produced successfully.
- Verified the release verification step succeeds for both architectures.

> This PR supersedes #78, which was closed after being opened against the wrong base branch.